### PR TITLE
Lower gcc/g++ version to 4.7 to match RetroPie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,24 @@ os:
 - osx
 
 before_install:
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y libsdl2-dev; fi
-- if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install sdl2; fi
+# --- RetroPie like environment ------------------------------------------------
+# Setup the same gcc/g++ version
+# http://askubuntu.com/a/26518
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y gcc-4.7; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y g++-4.7; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 10; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 10; fi
+# Install project dependencies
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
+- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libsdl2-dev; fi
+
+# --- OSX environment ----------------------------------------------------------
+# Install project dependencies
+- if [ $TRAVIS_OS_NAME == osx ]; then brew update; fi
+- if [ $TRAVIS_OS_NAME == osx ]; then brew install sdl2; fi
+
+# --- Generic setup ------------------------------------------------------------
 - cmake .
+
 
 script: make


### PR DESCRIPTION
We want to make sure that things will compile on RetroPie so we need to have
Travis running the same versions of "everything". For now we're setting up the
C/C++ compilers.
- Install gcc/g++ 4.7 and set up symlinks
