### PR TITLE
Naïve smoke test for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom a-retro-ui
 a_retro_ui
+a_retro_test
 *.vcxproj
 *.vcxproj.filters
 *.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,42 @@ os:
 
 before_install:
 # --- RetroPie like environment ------------------------------------------------
-# Setup the same gcc/g++ version
-# http://askubuntu.com/a/26518
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y gcc-4.7; fi
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y g++-4.7; fi
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 10; fi
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 10; fi
-# Install project dependencies
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update; fi
-- if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get install -y libsdl2-dev libfreeimage-dev lua5.1-dev; fi
+- |-
+  if [ $TRAVIS_OS_NAME == linux ]; then
+    # Enable graphics with xvfb
+    # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+    export DISPLAY=:99.0
+    sh -e /etc/init.d/xvfb start
+    sleep 3 # give xvfb some time to start
+
+    # Install project dependencies
+    sudo apt-get update
+    sudo apt-get install -y libsdl2-dev libfreeimage-dev lua5.1-dev
+
+    # Downgrade to the same gcc/g++ version as RetroPie 3.6
+    # http://askubuntu.com/a/26518
+    sudo apt-get install -y gcc-4.7
+    sudo apt-get install -y g++-4.7
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 10
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 10
+  fi
 
 # --- OSX environment ----------------------------------------------------------
-# Install project dependencies
-- if [ $TRAVIS_OS_NAME == osx ]; then brew update; fi
-- if [ $TRAVIS_OS_NAME == osx ]; then brew install sdl2 freeimage lua51; fi
+- |-
+  if [ $TRAVIS_OS_NAME == osx ]; then
+    # Install project dependencies
+    brew update
+    brew install sdl2 freeimage lua51
+  fi
 
 
-script: ./scripts/build.sh
+script:
+- ./scripts/build.sh
+
+- if [ $TRAVIS_OS_NAME == osx ]; then ./scripts/test.sh; fi
+# running the renderer in Travis only works for OSX at the moment, because the Travis Linux environment uses OpenGL ES 3 which makes our shaders fail with:
+# 0:7(14): error: no precision specified this scope for type `vec2'
+# 0:8(14): error: no precision specified this scope for type `vec3'
+# terminate called after throwing an instance of 'Shader::ShaderCompileError'
+#  what():  jw
+# ./test.sh: line 7: 12471 Aborted                 (core dumped) ./a_retro_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,7 @@ include_directories(
 	${DEPENDENCIES_INCLUDES}
 )
 
-# MAIN
-add_executable(a_retro_ui
-	src/main.cpp
+set(SOURCE_FILES
 	src/shader.h
 	src/shader.cpp
 	src/shader_program.h
@@ -65,7 +63,21 @@ add_executable(a_retro_ui
 	${DEPENDENCIES_SOURCES}
 )
 
+# MAIN
+add_executable(a_retro_ui
+	src/main.cpp
+	${SOURCE_FILES}
+)
 target_link_libraries(a_retro_ui
+	${DEPENDENCIES_LIBRARIES}
+)
+
+# TEST
+add_executable(a_retro_test
+	src/test.cpp
+	${SOURCE_FILES}
+)
+target_link_libraries(a_retro_test
 	${DEPENDENCIES_LIBRARIES}
 )
 

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,7 @@
+# [PowerShell script for Windows]
+
+# Smoke tests the application.
+
+echo "** Test project **"
+
+.\Debug\a_retro_test.exe

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Smoke tests the application.
+
+echo "** Test project **"
+
+./a_retro_test

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -323,6 +323,15 @@ int init_sdl_gl()
 		printf( "Warning: Unable to set VSync! SDL Error: %s\n", SDL_GetError() );
 	}
 
+	printf("----------------------------------------------------------------\n");
+	printf("Initialized OpenGL\n");
+	printf("OpenGL Info\n");
+	printf("    Version: %s\n", glGetString(GL_VERSION));
+	printf("     Vendor: %s\n", glGetString(GL_VENDOR));
+	printf("   Renderer: %s\n", glGetString(GL_RENDERER));
+	printf("    Shading: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
+	printf("----------------------------------------------------------------\n");
+
 	return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,15 +53,6 @@ int main( int argc, char* args[] )
 		return false;
 	}
 
-	printf("----------------------------------------------------------------\n");
-	printf("Initialized OpenGL\n");
-	printf("OpenGL Info\n");
-	printf("    Version: %s\n", glGetString(GL_VERSION));
-	printf("     Vendor: %s\n", glGetString(GL_VENDOR));
-	printf("   Renderer: %s\n", glGetString(GL_RENDERER));
-	printf("    Shading: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
-	printf("----------------------------------------------------------------\n");
-
 
 
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,0 +1,86 @@
+
+#include <iostream>
+
+#include "platform.h"
+#include "Renderer.h"
+#include "Input.h"
+
+extern "C"
+{
+	#include "lua.h"
+	#include "lualib.h"
+	#include "lauxlib.h"
+}
+
+static int lua_hello_world( lua_State* L )
+{
+	int argc = lua_gettop( L );
+	int argv = lua_tonumber( L, 1 );
+
+	printf( "Got data from Lua :: %d args :: '%d'\n", argc, argv );
+
+	lua_pushnumber( L, argc );
+	lua_pushnumber( L, argv );
+	return 2; // Number of lua_pushX calls.
+}
+
+int main( int argc, char* args[] )
+{
+	//Smoke test Lua.
+	printf( "¿¿ Smoke test Lua ??\n" );
+	lua_State* L = luaL_newstate();
+	luaL_openlibs( L );
+	lua_register( L, "lua_hello_world", lua_hello_world );
+	luaL_dofile( L, "hello_world.lua" );
+	lua_close( L );
+	L = nullptr;
+
+
+	// --- STARTUP ------------------------------
+
+	//Startup renderer.
+	printf( "¿¿ Startup renderer ??\n" );
+	if ( !init_sdl_gl() )
+		return 1;
+	Renderer_SDL_OpenGL renderer;
+	GLenum error = glGetError();
+	if( error != GL_NO_ERROR )
+	{
+		printf( "Unable to initialize OpenGL!\n%d\n", error );
+		return false;
+	}
+
+	//Startup input.
+	printf( "¿¿ Startup input ??\n" );
+	Input* input = new Input();
+
+
+	// --- TEST ---------------------------------
+
+	//Test run input.
+	printf( "¿¿ Test run input ??\n" );
+	input->poll_events();
+
+	//Test run renderer.
+	printf( "¿¿ Test run renderer ??\n" );
+	renderer.render();
+	SDL_GL_SwapWindow( gWindow );
+
+
+	// --- SHUTDOWN -----------------------------
+
+	//Shutdown input.
+	printf( "¿¿ Shutdown input ??\n" );
+	delete input;
+
+	//Shutdown renderer.
+	printf( "¿¿ Shutdown renderer ??\n" );
+	shutdown_sdl_gl();
+
+
+	// --- EXIT ---------------------------------
+
+	//Test successful.
+	printf( "¿¿ Test successful ??\n" );
+	return 0;
+}


### PR DESCRIPTION
References:
https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
http://stackoverflow.com/a/36451519
https://github.com/libSDL2pp/libSDL2pp/blob/master/.travis.yml

Starts the basic application and test runs:
- Lua
- SDL input poll
- OpenGL rendering context
  *\* Does not test shaders atm because Travis uses OpenGL ES 3.0 which we don't support

Running on Travis with xvfb, but only for OSX.
Add test.sh and test.ps1 convenience scripts. test.sh is used in .travis.yml.
