### PR TITLE
Add setup convenience scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ os:
 - osx
 
 before_install:
-# --- RetroPie like environment ------------------------------------------------
+- ./scripts/setup.sh
+
+# Hack around to get a RetroPie like environment
 - |-
   if [ $TRAVIS_OS_NAME == linux ]; then
     # Enable graphics with xvfb
@@ -30,15 +32,6 @@ before_install:
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 10
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 10
   fi
-
-# --- OSX environment ----------------------------------------------------------
-- |-
-  if [ $TRAVIS_OS_NAME == osx ]; then
-    # Install project dependencies
-    brew update
-    brew install sdl2 freeimage lua51
-  fi
-
 
 script:
 - ./scripts/build.sh

--- a/README.md
+++ b/README.md
@@ -8,37 +8,17 @@
 ### On Raspberry Pi
 *Tested on RetroPie +3.7*
 
-Install dependencies:
+Install dependencies with [setup.sh](scripts/setup.sh).
 
-```bash
-$ sudo apt-get install cmake libsdl2-dev libfreeimage-dev lua5.1-dev
-```
-
-Then, generate and build the Makefile with CMake:
-
-```bash
-cmake .
-make
-./a_retro_ui
-```
+Then, generate and build with [build.sh](scripts/build.sh).
 
 
 ### On OSX
 *Tested on OSX +10.10*
 
-You need [HomeBrew](http://brew.sh/) and then run:
+You need [HomeBrew](http://brew.sh/) and then run [setup.sh](scripts/setup.sh).
 
-```bash
-$ brew install cmake sdl2 freeimage lua51
-```
-
-Then, generate and build the Makefile with CMake:
-
-```bash
-cmake .
-make
-./a_retro_ui
-```
+Then, generate and build with [build.sh](scripts/build.sh).
 
 
 ### On Windows
@@ -46,10 +26,4 @@ make
 
 You need to have Visual Studio, and then install [CMake](https://cmake.org/download/). We recommend [CMake 3.5.0](https://cmake.org/files/v3.5/cmake-3.5.2-win32-x86.msi).
 
-Then, generate and build the Visual Studio Solution with CMake:
-
-```powershell
-cmake .
-msbuild .\ALL_BUILD.vcxproj
-.\Debug\a_retro_ui.exe
-```
+Then, generate and build with [build.ps1](scripts/build.ps1).

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,7 @@
+# [PowerShell script for Windows]
+
+# Installs project dependencies.
+
+"** Set up project **"
+
+"sorry... there's no package manager we can use like we use Homebrew on OSX or apt-get on Linux. You'll have to read the Readme.md for instructions :("

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Installs project dependencies.
+
+echo "** Set up project **"
+
+# --- RetroPie -----------------------------------------------------------------
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	echo "* RetroPie setup *"
+	sudo apt-get update
+	sudo apt-get install -y libsdl2-dev libfreeimage-dev lua5.1-dev
+
+# --- OSX ----------------------------------------------------------------------
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	echo "* Mac OSX setup *"
+	brew update
+	brew install sdl2 freeimage lua51
+
+fi


### PR DESCRIPTION
- setup.sh detects Linux and OSX, and uses apt-get or brew respectively
  to install dependencies needed for this project.
- Run setup.sh on Travis.
- setup.ps1 on Windows does absolutely nothing, because we can't rely on
  nuget nor chocolatey.
- Update readme
