### PR TITLE
Fix Windows build

### DIFF
--- a/src/Application_Main.h
+++ b/src/Application_Main.h
@@ -2,6 +2,7 @@
 #define A_RETRO_UI_APPLICATION_MAIN_H
 
 #include <iostream>
+#include <string>
 #include <vector>
 
 #include "Application.h"

--- a/src/Graphics_ShaderManager_OpenGL.h
+++ b/src/Graphics_ShaderManager_OpenGL.h
@@ -1,6 +1,7 @@
 #ifndef A_RETRO_UI_GRAPHICS_SHADERMANAGER_OPENGL_H
 #define A_RETRO_UI_GRAPHICS_SHADERMANAGER_OPENGL_H
 
+#include <algorithm>
 #include <unordered_map>
 #include <queue>
 
@@ -94,7 +95,8 @@ namespace RetroGraphics
 			{
 				GLsizei len;
 				glGetShaderiv( shader_handle, GL_INFO_LOG_LENGTH, &len );
-				GLchar msg[len];
+				GLchar msg[4096];
+				len = std::min(len, 4096);
 				glGetShaderInfoLog( shader_handle, len, &len, msg );
 				std::cout << "[shader manager opengl[ shader error '" << shader_type << "':" << std::endl;
 				std::cout << "    " << msg << std::endl;
@@ -124,7 +126,8 @@ namespace RetroGraphics
 			{
 				GLsizei len;
 				glGetProgramiv( prog_handle, GL_INFO_LOG_LENGTH, &len );
-				GLchar msg[len];
+				GLchar msg[4096];
+				len = std::min(len, 4096);
 				glGetProgramInfoLog( prog_handle, len, &len, msg );
 				std::cout << "[shader manager opengl] program error:" << std::endl;
 				std::cout << "    " << msg << std::endl;

--- a/src/Graphics_TextureManager_OpenGL.h
+++ b/src/Graphics_TextureManager_OpenGL.h
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <queue>
+#include <string>
 
 // TODO Remove free image dependency from this file!
 #include <FreeImage.h>

--- a/src/Resource_BitmapLoader.h
+++ b/src/Resource_BitmapLoader.h
@@ -1,6 +1,7 @@
 #ifndef A_RETRO_UI_BITMAPLOADER_H
 #define A_RETRO_UI_BITMAPLOADER_H
 
+#include <string>
 #include <vector>
 
 #include <FreeImage.h>

--- a/src/Resource_ShaderLoader.cpp
+++ b/src/Resource_ShaderLoader.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <string>
 #include <iostream>
 #include <fstream>
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -1,6 +1,14 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
+#ifdef _WIN32
+	// Windows (windef.h) defines macros we don't want.
+	// Reference: http://stackoverflow.com/a/4914108/703921
+	#define NOMINMAX
+	#define UNICODE
+	#define STRICT
+#endif
+
 #include <cstdint>
 #include <utility>
 


### PR DESCRIPTION
Not sure how this slipped passed us. Could be Windows 10 specific, but
there were several errors:
- Error C2131: expression did not evaluate to a constant
- Error C2679: binary '<<': no operator found which takes a right-hand
  operand of type 'const std::string' (or there is no acceptable
  conversion)

Note: It still has 48 warnings on Windows that are not fixed because
      the code is currently being mostly rewritten in another branch.
- warning C4018: '<': signed/unsigned mismatch
- warning C4099: 'RetroResource::BitmapCollection': type name first
  seen using 'struct' now seen using 'class'
