### PR TITLE
Remove *.dir directories on Windows that prevent rebuild

### DIFF
--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -7,3 +7,5 @@ echo "** Cleaning project **"
 rm .\CMakeCache.txt
 rm -r .\Win32
 rm -r .\Debug
+rm -r .\a_retro_test.dir
+rm -r .\a_retro_ui.dir


### PR DESCRIPTION
scripts/rebuild.ps1 wasn't really rebuilding because some directories
were still present after running scripts/clean.ps1, namely:
- .\a_retro_test.dir
- .\a_retro_ui.dir
