### PR TITLE
Create lib's from our shared sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Custom a-retro-ui
 a_retro_ui
 a_retro_test
+## OSX
+liba_retro_lib.a
+liba_retro_core.a
+## Windows
 *.vcxproj
 *.vcxproj.filters
 *.sln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,10 @@ include_directories(
 	${DEPENDENCIES_INCLUDES}
 )
 
-set(SOURCE_FILES
+add_library(a_retro_lib
 	${DEPENDENCIES_SOURCES}
-
+)
+add_library(a_retro_core
 	src/platform.h
 
 	src/Ioc_Container.h
@@ -105,23 +106,26 @@ set(SOURCE_FILES
 	src/Ui_SystemRenderer.h
 	src/Ui_SystemInput.h
 	src/Ui_SystemAnimator.h
-	src/Ui_ComponentInteraction.h src/Ui_SystemInteraction.h)
+	src/Ui_ComponentInteraction.h src/Ui_SystemInteraction.h
+)
 
 # MAIN
 add_executable(a_retro_ui
 	src/main.cpp
-	${SOURCE_FILES}
 )
 target_link_libraries(a_retro_ui
+	a_retro_lib
+	a_retro_core
 	${DEPENDENCIES_LIBRARIES}
 )
 
 # TEST
 add_executable(a_retro_test
 	src/test.cpp
-	${SOURCE_FILES}
 )
 target_link_libraries(a_retro_test
+	a_retro_lib
+	a_retro_core
 	${DEPENDENCIES_LIBRARIES}
 )
 


### PR DESCRIPTION
Create a_retro_lib for our dependencies and a_retro_core libraries
for our shared code so we don't need to recompile all the source files
twice when building the a_retro_test and a_retro_ui executables. This was
especially annoying on Raspberry Pi which is pretty slow.

The idea is to run `build.sh` but as a benchmark `time ./scripts/rebuild.sh` gives:

On MacBook Pro:
master: real 0m13.086s
jp/simple-shared-lib: real 0m9.646s

On Raspberry Pi 3:
master: 2m54.889s
jp/simple-shared-lib: 2m16.290s
